### PR TITLE
feat: add logical operator support

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -83,6 +83,13 @@ func TestEvalBooleanExpression(t *testing.T) {
 		{"(1 < 2) == false", false},
 		{"(1 > 2) == true", false},
 		{"(1 > 2) == false", true},
+		{"4 > 2 && 1 == 1", true},
+		{"4 < 2 && 1 == 1", false},
+		{"4 > 2 && 1 == 0", false},
+		{"7 > 3 || 7 == 7", true},
+		{"7 > 3 || 7 != 7", true},
+		{"7 < 3 || 7 == 7", true},
+		{"7 < 3 || 7 != 7", false},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +142,10 @@ func TestIfElseExpressions(t *testing.T) {
 		{"if (1 > 2) { 10 }", nil},
 		{"if (1 > 2) { 10 } else { 20 }", 20},
 		{"if (1 < 2) { 10 } else { 20 }", 10},
+		{"if (7 > 3 && 5 == 5) { 10 } else { 20 }", 10},
+		{"if (7 > 3 && 5 != 5) { 10 } else { 20 }", 20},
+		{"if (7 < 3 || 5 == 5) { 10 } else { 20 }", 10},
+		{"if (7 < 3 || 5 != 5) { 10 } else { 20 }", 20},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -82,6 +82,18 @@ func (l *Lexer) NextToken() token.Token {
 		} else {
 			tok = newToken(token.GT, l.ch)
 		}
+	case '&':
+		if l.peekChar() == '&' {
+			ch := l.ch
+			l.readChar()
+			tok = token.Token{Type: token.AND, Literal: string(ch) + string(l.ch)}
+		}
+	case '|':
+		if l.peekChar() == '|' {
+			ch := l.ch
+			l.readChar()
+			tok = token.Token{Type: token.OR, Literal: string(ch) + string(l.ch)}
+		}
 	case ';':
 		tok = newToken(token.SEMICOLON, l.ch)
 	case '(':

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -246,6 +246,9 @@ func TestNextToken6(t *testing.T) {
 2 <= 5
 8 >= 1
 2 ** 2
+
+a && b
+a || b
 `
 	tests := []struct {
 		expectedType    token.TokenType
@@ -276,6 +279,13 @@ func TestNextToken6(t *testing.T) {
 		{token.NUM, "2"},
 		{token.POWER, "**"},
 		{token.NUM, "2"},
+
+		{token.IDENT, "a"},
+		{token.AND, "&&"},
+		{token.IDENT, "b"},
+		{token.IDENT, "a"},
+		{token.OR, "||"},
+		{token.IDENT, "b"},
 
 		{token.EOF, ""},
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -59,6 +59,8 @@ func New(lexer *lexer.Lexer) *Parser {
 	p.registerBinaryParser(token.GT, p.parseBinaryExpression)
 	p.registerBinaryParser(token.LTE, p.parseBinaryExpression)
 	p.registerBinaryParser(token.GTE, p.parseBinaryExpression)
+	p.registerBinaryParser(token.AND, p.parseBinaryExpression)
+	p.registerBinaryParser(token.OR, p.parseBinaryExpression)
 	p.registerBinaryParser(token.LPAREN, p.parseCallExpression)
 	p.registerBinaryParser(token.LBRACKET, p.parseIndexExpression)
 
@@ -165,14 +167,14 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	leftExp := unaryFn()
 
 	for !p.peekTokenIs(token.SEMICOLON) && precedence < p.peekPrecedence() {
-		binary := p.binaryParsers[p.peekToken.Type]
-		if binary == nil {
+		binaryFn := p.binaryParsers[p.peekToken.Type]
+		if binaryFn == nil {
 			return leftExp
 		}
 
 		p.nextToken()
 
-		leftExp = binary(leftExp)
+		leftExp = binaryFn(leftExp)
 	}
 
 	return leftExp

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -323,6 +323,8 @@ func TestParsingBinaryExpressions(t *testing.T) {
 		{"5 <= 5;", 5, "<=", 5},
 		{"5 == 5;", 5, "==", 5},
 		{"5 != 5;", 5, "!=", 5},
+		{"5 && 5;", 5, "&&", 5},
+		{"5 || 5;", 5, "||", 5},
 		{"true == true", true, "==", true},
 		{"true != false", true, "!=", false},
 		{"false == false", false, "==", false},

--- a/parser/precedence.go
+++ b/parser/precedence.go
@@ -5,6 +5,7 @@ import "github.com/darwin1224/saphire/token"
 const (
 	_ int = iota
 	LOWEST
+	LOGICAL
 	EQUALS
 	LESSGREATER
 	SUM
@@ -15,6 +16,8 @@ const (
 )
 
 var precedences = map[token.TokenType]int{
+	token.AND:      LOGICAL,
+	token.OR:       LOGICAL,
 	token.EQ:       EQUALS,
 	token.NOT_EQ:   EQUALS,
 	token.LT:       LESSGREATER,

--- a/token/token.go
+++ b/token/token.go
@@ -29,6 +29,8 @@ const (
 	GTE      = ">="
 	EQ       = "=="
 	NOT_EQ   = "!="
+	AND      = "&&"
+	OR       = "||"
 
 	COMMA     = ","
 	SEMICOLON = ";"


### PR DESCRIPTION
# Description

Add support for logical operator.

# Example

```
let f = fn(x, y) {
  if (x > 1 && y > 1) {
    true
  } else {
    false
  }
}

let g = fn(x, y) {
  if (x == 1 || y == 2) {
    true
  } else {
    false
  }
}

print(f(0, 0)) // false
print(g(1, 0)) // true
print(g(0, 2)) // true
print(g(0, 0)) // false
```