### PR TITLE
fix: prevent lexer hang on trailing // comments at EOF

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -151,10 +151,12 @@ func (l *Lexer) skipWhitespace() {
 
 func (l *Lexer) skipComments() {
 	if l.ch == '/' && l.peekChar() == '/' {
-		for l.ch != '\n' {
+		for l.ch != '\n' && l.ch != 0 {
 			l.readChar()
 		}
-		l.readChar()
+		if l.ch == '\n' {
+			l.readChar()
+		}
 		l.skipWhitespace()
 
 		if l.ch == '/' {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -291,3 +291,31 @@ func TestNextToken6(t *testing.T) {
 		}
 	}
 }
+
+func TestNextTokenTrailingCommentWithoutNewline(t *testing.T) {
+	input := "let a = 1; // trailing comment"
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.NUM, "1"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- `skipComments` previously looped only until a newline and did not check for EOF, allowing input that ends with `//` and no trailing newline to cause an infinite loop and hang the interpreter (availability DoS).

### Description
- Stop scanning line comments at EOF by changing the loop condition to `for l.ch != '\n' && l.ch != 0` in `lexer.skipComments`.
- Preserve previous behavior for newline-terminated comments by consuming the newline only when `l.ch == '\n'` before continuing to skip whitespace.
- Add a regression test `TestNextTokenTrailingCommentWithoutNewline` in `lexer/lexer_test.go` that exercises input ending with a `//` comment and no trailing newline.
- Files changed: `lexer/lexer.go` and `lexer/lexer_test.go`.

### Testing
- Ran `go test ./...` and all package tests succeeded (including `github.com/darwin1224/saphire/lexer`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b017f569b88328a15d626cb0aebf7f)